### PR TITLE
Fix rough hover animations on headshot and technology icons

### DIFF
--- a/frontend/src/stylesheets/App.css
+++ b/frontend/src/stylesheets/App.css
@@ -33,11 +33,11 @@
   object-fit: cover;
   border-radius: 50%;
   border: 3px solid var(--theme-purple);
-  transition: filter 300ms;
+  transition: box-shadow 300ms ease;
 }
 
 .headshot:hover {
-  filter: drop-shadow(0 0 1.5em var(--theme-purple));
+  box-shadow: 0 0 1.5em var(--theme-purple);
 }
 
 .home-page-container h1 {
@@ -79,6 +79,7 @@
   gap: var(--space-1);
   color: var(--theme-muted);
   font-size: var(--text-sm);
+  transition: color 300ms ease;
 }
 
 .icon-link:hover {
@@ -90,7 +91,8 @@
   width: 50px;
   height: 50px;
   object-fit: contain;
-  transition: filter 300ms;
+  transition: filter 300ms ease;
+  will-change: filter;
 }
 
 .icon-link:hover .icon {


### PR DESCRIPTION
## Summary
- Headshot hover used `filter: drop-shadow()` on a circular (`border-radius: 50%`) image, which briefly rasterizes against the square alpha box before the circular clip settles — causing a visible square flash. Swapped to `box-shadow`, which respects `border-radius` natively.
- Technology icon hover had two smaller sync issues: the label `color` snapped instantly while the icon's `filter` faded over 300ms, and the first hover incurred a compositing-layer allocation stutter. Added a matching `color` transition and `will-change: filter`.

## Test plan
- [x] Verified visually via `npm run dev` — headshot glow is now clean and circular through the whole transition
- [x] Verified technology icon label and glow now fade in sync with no stutter on first hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)