### PR TITLE
Accessibility, error boundaries, and mobile responsiveness improvements (#61, #62, #65)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "react-router-dom": "^7.18.1"
       },
       "devDependencies": {
+        "@axe-core/react": "^4.12.1",
         "@eslint/js": "^9.39.2",
         "@playwright/test": "^1.61.1",
         "@testing-library/jest-dom": "^6.9.1",
@@ -24,6 +25,7 @@
         "@vitejs/plugin-react-swc": "^4.3.1",
         "@vitest/coverage-v8": "^4.1.10",
         "@vitest/ui": "^4.0.15",
+        "axe-core": "^4.12.1",
         "eslint": "^9.39.2",
         "eslint-plugin-react": "^7.37.0",
         "eslint-plugin-react-hooks": "^7.1.1",
@@ -96,6 +98,17 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@axe-core/react": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/react/-/react-4.12.1.tgz",
+      "integrity": "sha512-8tZysxguMYomHHFA1iPSpJfWiHX0LPSXdHxboR1YKPs+taNOG8wiEqLaGdgXaFDZ2WKyX/+bzvlLcqdNsR/Gdg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.12.1",
+        "requestidlecallback": "^0.3.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -2109,6 +2122,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/balanced-match": {
@@ -5208,6 +5231,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/requestidlecallback": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/requestidlecallback/-/requestidlecallback-0.3.0.tgz",
+      "integrity": "sha512-TWHFkT7S9p7IxLC5A1hYmAYQx2Eb9w1skrXmQ+dS1URyvR8tenMLl4lHbqEOUnpEYxNKpkVMXUgknVpBZWXXfQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
     "react-router-dom": "^7.18.1"
   },
   "devDependencies": {
+    "@axe-core/react": "^4.12.1",
     "@eslint/js": "^9.39.2",
     "@playwright/test": "^1.61.1",
     "@testing-library/jest-dom": "^6.9.1",
@@ -44,6 +45,7 @@
     "@vitejs/plugin-react-swc": "^4.3.1",
     "@vitest/coverage-v8": "^4.1.10",
     "@vitest/ui": "^4.0.15",
+    "axe-core": "^4.12.1",
     "eslint": "^9.39.2",
     "eslint-plugin-react": "^7.37.0",
     "eslint-plugin-react-hooks": "^7.1.1",

--- a/frontend/src/App.a11y.test.tsx
+++ b/frontend/src/App.a11y.test.tsx
@@ -1,0 +1,11 @@
+import { render } from '@testing-library/react';
+import { describe, it } from 'vitest';
+import App from './App';
+import { expectNoA11yViolations } from './test/axe';
+
+describe('App accessibility', () => {
+  it('the full app shell (nav, main, footer) has no WCAG A/AA violations', async () => {
+    const { container } = render(<App />);
+    await expectNoA11yViolations(container);
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,28 +1,43 @@
 import './stylesheets/App.css';
 import React from 'react';
-import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
+import { BrowserRouter as Router, Route, Routes, useLocation } from 'react-router-dom';
 import MenuBar from './components/MenuBar';
 import Home from './pages/Home';
 import About from './pages/About';
 import Projects from './pages/Projects';
 import Resume from './pages/Resume';
 import Footer from './components/Footer';
+import ErrorBoundary from './components/ErrorBoundary';
 
 const App: React.FC = () => {
   return (
-    <Router>
-      <MenuBar />
-      <main className="main-content">
-        <Routes>
-          <Route path="/" element={<Home />} />
-          <Route path="/about" element={<About />} />
-          <Route path="/projects" element={<Projects />} />
-          <Route path="/resume" element={<Resume />} />
-        </Routes>
-      </main>
-      <Footer />
-    </Router>
+    // Top-level boundary is the last line of defense (e.g. router/nav failures).
+    <ErrorBoundary>
+      <Router>
+        <MenuBar />
+        <main className="main-content">
+          {/* Per-route boundary keyed on pathname: a crash on one page shows a
+              fallback but keeps the nav and footer intact, and resets on
+              navigation. */}
+          <RouteBoundary>
+            <Routes>
+              <Route path="/" element={<Home />} />
+              <Route path="/about" element={<About />} />
+              <Route path="/projects" element={<Projects />} />
+              <Route path="/resume" element={<Resume />} />
+            </Routes>
+          </RouteBoundary>
+        </main>
+        <Footer />
+      </Router>
+    </ErrorBoundary>
   );
+};
+
+// Remounts the boundary on each route change so navigating away clears an error.
+const RouteBoundary: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { pathname } = useLocation();
+  return <ErrorBoundary key={pathname}>{children}</ErrorBoundary>;
 };
 
 export default App;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,8 +11,11 @@ import Footer from './components/Footer';
 const App: React.FC = () => {
   return (
     <Router>
+      <a href="#main-content" className="skip-link">
+        Skip to main content
+      </a>
       <MenuBar />
-      <main className="main-content">
+      <main id="main-content" className="main-content" tabIndex={-1}>
         <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/about" element={<About />} />

--- a/frontend/src/components/ErrorBoundary.test.tsx
+++ b/frontend/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,91 @@
+import type React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import ErrorBoundary from './ErrorBoundary';
+
+// Component that throws on demand so we can exercise the error path.
+const Boom: React.FC<{ shouldThrow: boolean }> = ({ shouldThrow }) => {
+  if (shouldThrow) {
+    throw new Error('boom');
+  }
+  return <div>Safe child</div>;
+};
+
+describe('ErrorBoundary Component', () => {
+  beforeEach(() => {
+    // Suppress React's expected error logging for the thrown-error cases.
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders its children when there is no error', () => {
+    render(
+      <ErrorBoundary>
+        <Boom shouldThrow={false} />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('Safe child')).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('renders the fallback UI when a child throws', () => {
+    render(
+      <ErrorBoundary>
+        <Boom shouldThrow={true} />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /something went wrong/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /reload page/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /go home/i })).toBeInTheDocument();
+    expect(screen.queryByText('Safe child')).not.toBeInTheDocument();
+  });
+
+  it('logs the caught error via componentDidCatch', () => {
+    render(
+      <ErrorBoundary>
+        <Boom shouldThrow={true} />
+      </ErrorBoundary>
+    );
+
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it('renders a custom fallback when provided', () => {
+    render(
+      <ErrorBoundary fallback={<div>Custom fallback</div>}>
+        <Boom shouldThrow={true} />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('Custom fallback')).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('reloads the page when the reload button is clicked', async () => {
+    const reload = vi.fn();
+    const original = window.location;
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...original, reload },
+    });
+
+    const user = userEvent.setup();
+    render(
+      <ErrorBoundary>
+        <Boom shouldThrow={true} />
+      </ErrorBoundary>
+    );
+
+    await user.click(screen.getByRole('button', { name: /reload page/i }));
+    expect(reload).toHaveBeenCalledOnce();
+
+    Object.defineProperty(window, 'location', { configurable: true, value: original });
+  });
+});

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,63 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import '../stylesheets/ErrorBoundary.css';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  /** Optional custom fallback UI to render instead of the default. */
+  fallback?: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+/**
+ * Reusable error boundary. Catches render/lifecycle errors in its subtree and
+ * shows a friendly fallback instead of letting the whole app crash.
+ */
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    // No backend/logging service; surface to the console for debugging.
+    console.error('ErrorBoundary caught an error:', error, errorInfo);
+  }
+
+  handleReload = (): void => {
+    window.location.reload();
+  };
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      if (this.props.fallback !== undefined) {
+        return this.props.fallback;
+      }
+
+      return (
+        <div className="error-boundary" role="alert">
+          <h1 className="error-boundary-title">Something went wrong</h1>
+          <p className="error-boundary-text">
+            Sorry, an unexpected error occurred. Try reloading the page, or head back to the home
+            page.
+          </p>
+          <div className="error-boundary-actions">
+            <button type="button" className="button" onClick={this.handleReload}>
+              Reload page
+            </button>
+            <a className="button" href="/">
+              Go home
+            </a>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/frontend/src/components/MenuBar.tsx
+++ b/frontend/src/components/MenuBar.tsx
@@ -16,7 +16,7 @@ const MenuBar: React.FC = () => {
   };
 
   return (
-    <nav>
+    <nav aria-label="Primary">
       <Link to={ROUTES.HOME} className="wordmark" onClick={closeMenu}>
         {APP_CONFIG.author}
       </Link>
@@ -24,11 +24,12 @@ const MenuBar: React.FC = () => {
         className="menu-toggle"
         onClick={toggleMenu}
         aria-expanded={isMenuOpen}
+        aria-controls="primary-menu"
         aria-label="Toggle navigation"
       >
-        ☰
+        <span aria-hidden="true">☰</span>
       </button>
-      <ul className={isMenuOpen ? 'show' : ''}>
+      <ul id="primary-menu" className={isMenuOpen ? 'show' : ''}>
         <MenuItem to={ROUTES.HOME} label="Home" onClick={closeMenu} />
         <MenuItem to={ROUTES.ABOUT} label="About" onClick={closeMenu} />
         <MenuItem to={ROUTES.PROJECTS} label="Projects" onClick={closeMenu} />

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,20 @@ import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './stylesheets/index.css';
 
+// Development-only accessibility auditing. @axe-core/react logs WCAG
+// violations to the browser console on every render so issues surface
+// during local development without shipping any code to production.
+if (import.meta.env.DEV) {
+  void (async () => {
+    const [{ default: React }, { default: ReactDOM }, { default: axe }] = await Promise.all([
+      import('react'),
+      import('react-dom'),
+      import('@axe-core/react'),
+    ]);
+    await axe(React, ReactDOM, 1000);
+  })();
+}
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />

--- a/frontend/src/pages/Home.test.tsx
+++ b/frontend/src/pages/Home.test.tsx
@@ -14,10 +14,10 @@ describe('Home Component', () => {
     expect(screen.getByText(/cloud engineer based in the denver area/i)).toBeInTheDocument();
   });
 
-  it('shows an icon for every technology', () => {
+  it('shows a labeled link for every technology', () => {
     render(<Home />);
     for (const tech of TECHNOLOGIES) {
-      expect(screen.getByAltText(tech.name)).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: tech.name })).toBeInTheDocument();
     }
   });
 

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -5,8 +5,13 @@ import { APP_CONFIG, EXTERNAL_LINKS, TECHNOLOGIES } from '../constants';
 const Home: React.FC = () => {
   return (
     <div className="home-page-container">
-      <a href={EXTERNAL_LINKS.GITHUB} target="_blank" rel="noopener noreferrer">
-        <img src={headshotPhoto} className="headshot" alt="Recent headshot of Parker (2023)" />
+      <a
+        href={EXTERNAL_LINKS.GITHUB}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Parker Lacy's GitHub profile (opens in a new tab)"
+      >
+        <img src={headshotPhoto} className="headshot" alt="Headshot of Parker Lacy" />
       </a>
       <h1>Parker Lacy</h1>
       <div className="home-page-text">
@@ -25,7 +30,7 @@ const Home: React.FC = () => {
             rel="noopener noreferrer"
             className="icon-link"
           >
-            <img src={tech.icon} alt={tech.name} className="icon" />
+            <img src={tech.icon} alt="" className="icon" />
             <span>{tech.name}</span>
           </a>
         ))}

--- a/frontend/src/pages/pages.a11y.test.tsx
+++ b/frontend/src/pages/pages.a11y.test.tsx
@@ -1,0 +1,36 @@
+import { render } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { describe, it } from 'vitest';
+import Home from './Home';
+import About from './About';
+import Projects from './Projects';
+import Resume from './Resume';
+import { expectNoA11yViolations } from '../test/axe';
+
+// Each page's main content is wrapped in a <main> landmark by App at
+// runtime, so wrap it here too to give axe an equivalent landmark context.
+function renderInMain(ui: ReactElement) {
+  return render(<main>{ui}</main>);
+}
+
+describe('Page accessibility', () => {
+  it('Home page has no WCAG A/AA violations', async () => {
+    const { container } = renderInMain(<Home />);
+    await expectNoA11yViolations(container);
+  });
+
+  it('About page has no WCAG A/AA violations', async () => {
+    const { container } = renderInMain(<About />);
+    await expectNoA11yViolations(container);
+  });
+
+  it('Projects page has no WCAG A/AA violations', async () => {
+    const { container } = renderInMain(<Projects />);
+    await expectNoA11yViolations(container);
+  });
+
+  it('Resume page has no WCAG A/AA violations', async () => {
+    const { container } = renderInMain(<Resume />);
+    await expectNoA11yViolations(container);
+  });
+});

--- a/frontend/src/stylesheets/App.css
+++ b/frontend/src/stylesheets/App.css
@@ -6,6 +6,7 @@
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+  min-height: 100dvh;
 }
 
 .main-content {

--- a/frontend/src/stylesheets/ErrorBoundary.css
+++ b/frontend/src/stylesheets/ErrorBoundary.css
@@ -1,0 +1,34 @@
+/* ERROR BOUNDARY FALLBACK */
+
+.error-boundary {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  max-width: 34rem;
+  margin: 0 auto;
+  padding: var(--space-5) var(--space-4);
+}
+
+.error-boundary-title {
+  margin-bottom: var(--space-3);
+}
+
+.error-boundary-text {
+  color: var(--theme-muted);
+  margin-bottom: var(--space-4);
+}
+
+.error-boundary-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: var(--space-3);
+}
+
+.error-boundary-actions .button {
+  cursor: pointer;
+  border: none;
+  font-size: var(--text-base);
+  font-family: inherit;
+}

--- a/frontend/src/stylesheets/MenuBar.css
+++ b/frontend/src/stylesheets/MenuBar.css
@@ -51,6 +51,11 @@ nav ul a.active {
 /* Toggle button for small screens */
 .menu-toggle {
   display: none;
+  align-items: center;
+  justify-content: center;
+  /* Comfortable ~44px tap target for touch devices. */
+  min-width: 44px;
+  min-height: 44px;
   background: none;
   color: var(--theme-white);
   border: none;
@@ -67,7 +72,7 @@ nav ul a.active {
   }
 
   .menu-toggle {
-    display: block;
+    display: flex;
   }
 
   nav ul {
@@ -82,7 +87,7 @@ nav ul a.active {
   }
 
   nav ul a {
-    padding: var(--space-2) var(--space-2);
+    padding: var(--space-3) var(--space-2);
   }
 
   nav ul a.active {

--- a/frontend/src/stylesheets/Projects.css
+++ b/frontend/src/stylesheets/Projects.css
@@ -1,6 +1,8 @@
 .project-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  /* min(280px, 100%) keeps a single card from exceeding the viewport on
+     narrow screens (a bare 280px min would overflow below ~330px wide). */
+  grid-template-columns: repeat(auto-fill, minmax(min(280px, 100%), 1fr));
   gap: var(--space-4);
   margin-top: var(--space-5);
   padding: 0;

--- a/frontend/src/stylesheets/index.css
+++ b/frontend/src/stylesheets/index.css
@@ -32,20 +32,38 @@
   color-scheme: dark;
 }
 
+/* Border-box everywhere so padding never pushes elements past the viewport
+   and triggers horizontal scroll on small screens. */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
 body {
   margin: 0;
   padding: 0;
   min-width: 320px;
   min-height: 100vh;
+  /* dvh tracks the visible viewport as mobile browser chrome shows/hides,
+     avoiding the extra scroll space that 100vh leaves. */
+  min-height: 100dvh;
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   font-weight: 400;
   line-height: 1.6;
   color: var(--theme-white);
   background-color: var(--theme-black);
+  /* Break long, unbroken strings (e.g. URLs) instead of overflowing. */
+  overflow-wrap: break-word;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+/* Images never exceed their container, preventing overflow on narrow screens. */
+img {
+  max-width: 100%;
 }
 
 h1 {

--- a/frontend/src/stylesheets/index.css
+++ b/frontend/src/stylesheets/index.css
@@ -79,6 +79,42 @@ a:hover {
   text-decoration: underline;
 }
 
+/* Visible keyboard focus indicator for every interactive element
+   (WCAG 2.4.7 Focus Visible). :focus-visible keeps the outline off
+   mouse clicks while showing it for keyboard/AT users. */
+a:focus-visible,
+button:focus-visible,
+[tabindex]:focus-visible {
+  outline: 3px solid var(--theme-light-purple);
+  outline-offset: 2px;
+  border-radius: var(--radius);
+}
+
+/* The <main> region receives focus when the skip link is used; it is
+   a programmatic target only, so suppress its outline. */
+main:focus-visible {
+  outline: none;
+}
+
+/* Skip link: visually hidden until focused, then pinned to the top-left
+   so keyboard users can jump straight to the main content. */
+.skip-link {
+  position: absolute;
+  left: var(--space-2);
+  top: -100%;
+  z-index: 2000;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius);
+  background-color: var(--theme-purple);
+  color: var(--theme-white);
+  font-weight: 600;
+}
+
+.skip-link:focus {
+  top: var(--space-2);
+  text-decoration: none;
+}
+
 /* Media Queries */
 @media (max-width: 768px) {
   :root {

--- a/frontend/src/test/axe.ts
+++ b/frontend/src/test/axe.ts
@@ -1,0 +1,30 @@
+import axe from 'axe-core';
+import { expect } from 'vitest';
+
+/**
+ * Runs axe-core against a rendered container and fails the test if any
+ * WCAG 2.0/2.1 A or AA violations are found.
+ *
+ * Only WCAG A/AA tagged rules are run (not axe "best-practice" rules) so
+ * the assertions map directly to the standards the site is expected to meet.
+ * The color-contrast rule needs real layout, which jsdom cannot provide, so
+ * axe reports it as "incomplete" rather than a violation here — contrast is
+ * instead exercised at runtime via @axe-core/react during development.
+ */
+export async function expectNoA11yViolations(container: HTMLElement): Promise<void> {
+  const results = await axe.run(container, {
+    runOnly: {
+      type: 'tag',
+      values: ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'],
+    },
+  });
+
+  if (results.violations.length > 0) {
+    const summary = results.violations
+      .map(v => `- [${v.id}] ${v.help} (${v.nodes.length} node(s)) — ${v.helpUrl}`)
+      .join('\n');
+    expect.fail(`Accessibility violations found:\n${summary}`);
+  }
+
+  expect(results.violations).toHaveLength(0);
+}

--- a/frontend/src/test/axe.ts
+++ b/frontend/src/test/axe.ts
@@ -7,15 +7,19 @@ import { expect } from 'vitest';
  *
  * Only WCAG A/AA tagged rules are run (not axe "best-practice" rules) so
  * the assertions map directly to the standards the site is expected to meet.
- * The color-contrast rule needs real layout, which jsdom cannot provide, so
- * axe reports it as "incomplete" rather than a violation here — contrast is
- * instead exercised at runtime via @axe-core/react during development.
+ * The color-contrast rule is disabled: it samples rendered pixels via canvas,
+ * which jsdom does not implement, so it can only ever report "incomplete" here
+ * (and logs a canvas warning per run). Contrast is instead exercised at runtime
+ * via @axe-core/react during development.
  */
 export async function expectNoA11yViolations(container: HTMLElement): Promise<void> {
   const results = await axe.run(container, {
     runOnly: {
       type: 'tag',
       values: ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'],
+    },
+    rules: {
+      'color-contrast': { enabled: false },
     },
   });
 


### PR DESCRIPTION
Combines three independently-developed frontend improvements into a single branch.

Closes #61
Closes #62
Closes #65

## #61 — Accessibility audits and improvements

**Tooling**
- `@axe-core/react` for dev-time runtime audits, dynamically imported behind `import.meta.env.DEV` so it logs WCAG violations during development but is tree-shaken out of the production bundle.
- `axe-core`-driven automated assertions via a shared `src/test/axe.ts` helper (filtered to WCAG 2.0/2.1 A/AA rules), with new suites covering the app shell and every page.

**WCAG fixes**
- Skip link to main content (2.4.1), visible only on focus; `<main>` given `id="main-content"` + `tabIndex={-1}` as the target.
- `:focus-visible` outline styles for links/buttons/tabindex elements (2.4.7) — previously only `:hover` states existed.
- `<nav aria-label="Primary">`; mobile toggle given `aria-controls` with its `☰` glyph marked `aria-hidden`.
- Explicit `aria-label` on the headshot GitHub link; technology icons made decorative (`alt=""`) so each link exposes one clean accessible name.

> Note: axe's `color-contrast` rule can't compute in jsdom (no layout), so it is disabled to avoid extraneous warnings during test runs.

## #62 — React error boundaries

- New reusable `ErrorBoundary` class component (`getDerivedStateFromError` + `componentDidCatch`) with a friendly fallback UI offering "Reload page" / "Go home", styled with the site's existing design tokens. Supports an optional `fallback` prop.
- Wired into `App.tsx` as a top-level boundary (last line of defense for router/nav failures) plus an inner `RouteBoundary` keyed on `pathname`, so a single page crash keeps the nav and footer intact and resets automatically on navigation.
- Unit tests cover normal render, default and custom fallbacks, `componentDidCatch` logging, and reload behavior.

## #65 — Mobile responsiveness and cross-browser compatibility

- Global `box-sizing: border-box` reset so padding can't push content past the viewport.
- `min-height: 100dvh` fallback after `100vh` on `body` and `#root` — `dvh` tracks the visible viewport as mobile browser chrome shows/hides.
- `overflow-wrap: break-word` for long unbreakable strings (e.g. URLs on the About page), and a global `img { max-width: 100% }` safeguard.
- Fixed a real overflow bug in the projects grid: `minmax(280px, 1fr)` forced a track wider than the ~272px content area on 320px phones → `minmax(min(280px, 100%), 1fr)`.
- Larger touch targets: ~44px hamburger toggle, increased mobile nav link padding.

## Merge notes

`App.tsx` was the one conflict — #61 and #62 both restructured the router tree. The resolution is a union of both intents, not a pick: the error boundaries wrap the router, with the skip link and `<main>` landmark attributes nested inside. Overlapping edits to `index.css` from #61 and #65 auto-merged cleanly and were reviewed by hand.

## Validation

Run against the merged branch:

- `npm run lint` — 0 errors
- `npm run test:run` — **28 passed** across 9 files (union of all three branches' suites)
- `npm run build` — succeeds; axe tooling confirmed dev-only (vendor bundle 230.79 kB / 73.87 kB gzip)
- `npm run format:check` — Prettier clean
- `npm run test:e2e` — **6/6** Playwright smoke tests pass against the real production build, including the "no console errors on load" check
- Manually verified via `vite preview`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
